### PR TITLE
Transfer smallest workflows first.

### DIFF
--- a/Unified/transferor.py
+++ b/Unified/transferor.py
@@ -93,6 +93,7 @@ def transferor(url ,specific = None, talk=True, options=None):
 
     transfers_per_sites = defaultdict(int)
     input_sizes = {}
+    primary_input_per_workflow_gb = defaultdict(float)
     input_cput = {}
     input_st = {}
     ## list the size of those in transfer already
@@ -111,6 +112,7 @@ def transferor(url ,specific = None, talk=True, options=None):
         for prim in primary:  
             input_sizes[prim] = dss.get( prim )
             print "\t",wfo.name,"needs",input_sizes[prim],"GB"
+            primary_input_per_workflow_gb[wfo.name] += input_sizes[prim]
         in_transfer_priority = max(in_transfer_priority, int(wfh.request['RequestPriority']))
         min_transfer_priority = min(min_transfer_priority, int(wfh.request['RequestPriority']))
 
@@ -124,9 +126,10 @@ def transferor(url ,specific = None, talk=True, options=None):
     st_in_transfer_already = sum(input_st.values())
     # shuffle first by name
     random.shuffle( wfs_and_wfh )
+    # Sort smallest transfers first; allows us to transfer as many as possible workflows.
+    wfs_and_wfh.sort(cmp = lambda i,j : cmp(int(primary_input_per_workflow_gb.get(i[0].name, 0)/100.), int(primary_input_per_workflow_gb.get(j[0].name, 0)/100.) ))
     #sort by priority higher first
     wfs_and_wfh.sort(cmp = lambda i,j : cmp(int(i[1].request['RequestPriority']),int(j[1].request['RequestPriority']) ), reverse=True)
-    
 
     ## list the size of all inputs
     print "getting all input sizes ..."


### PR DESCRIPTION
When there's a standing queue, this will get as many workflows
moving as possible while still obeying priorities.

Note that this rounds to 100GB chunks; I wanted to keep some effect of the initial shuffling.
