### PR TITLE
Sort DESIRED_Sites list.

### DIFF
--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -8,7 +8,8 @@ import classad
 import htcondor
 from collections import defaultdict
 
-def makeAds( config ):
+
+def makeAds(config):
     reversed_mapping = config['reversed_mapping']
 
     needs_site = defaultdict(set)
@@ -40,14 +41,27 @@ def makeAds( config ):
         overflow_names_escaped = anAd.lookup('OverflowTasknames').__repr__()
         del anAd['OverflowTaskNames']
         exprs = ['regexp(%s, target.ExtDESIRED_Sites)'% classad.quote(str(origin)) for origin in reversed_mapping[site]]
-        exp = classad.ExprTree('member(target.WMAgent_SubTaskName, %s) && ( %s ) && (target.HasBeenRouted_%s =!= true)' % (overflow_names_escaped, str("||".join( exprs )), str(site)))
+        exp = classad.ExprTree('(sortStringSet(\"\") isnt error) && member(target.WMAgent_SubTaskName, %s) && ( %s ) && (target.HasBeenRouted_%s =!= true)' % (overflow_names_escaped, str("||".join( exprs )), str(site)))
         anAd["Requirements"] = classad.ExprTree(str(exp))
         anAd["copy_DESIRED_Sites"] = "Prev_DESIRED_Sites"
-        anAd["eval_set_DESIRED_Sites"] = classad.Function("strcat", str(site) + ",", classad.Attribute("Prev_DESIRED_Sites"))
+        anAd["eval_set_DESIRED_Sites"] = classad.Function("debug", classad.Function("sortStringSet", classad.Function("strcat", str(site) + ",", classad.Attribute("Prev_DESIRED_Sites"))))
         anAd['set_Rank'] = classad.ExprTree("stringlistmember(GLIDEIN_CMSSite, ExtDESIRED_Sites)")
         anAd['set_HasBeenRouted'] = False
         anAd['set_HasBeenRouted_%s' % str(site)] = True
         print anAd
+
+
+def makeSortAd():
+    anAd = classad.ClassAd()
+    anAd["GridResource"] = "condor localhost localhost"
+    anAd["TargetUniverse"] = 5
+    anAd["Name"] = "Sort Ads"
+    anAd["Requirements"] = classad.ExprTree("(sortStringSet(\"\") isnt error) && (target.HasBeenRouted is false) && (target.HasBeenSorted isnt true) && (sortStringSet("") isnt error)")
+    anAd["copy_DESIRED_Sites"] = "Prev_DESIRED_Sites"
+    anAd["eval_set_DESIRED_Sites"] = classad.ExprTree("debug(sortStringSet(Prev_DESIRED_Sites))")
+    anAd["set_HasBeenSorted"] = True
+    print anAd
+
 
 if __name__ == "__main__":
 
@@ -56,3 +70,4 @@ if __name__ == "__main__":
 
     config = json.load(urllib.urlopen(htcondor.param['UNIFIED_OVERFLOW_CONFIG']))
     makeAds(config)
+    makeSortAd()

--- a/Unified/job_router_modules/unified_utils.py
+++ b/Unified/job_router_modules/unified_utils.py
@@ -1,0 +1,17 @@
+
+import re
+import classad
+
+_split_re = re.compile(",\s*")
+def sortStringSet(in_list, state={}):
+    if isinstance(in_list, classad.ExprTree):
+        in_list = in_list.eval(state)
+    if isinstance(in_list, classad.Value):
+        return classad.Value.Undefined
+    split_list = _split_re.split(in_list)
+    split_list = list(set(split_list))
+    split_list.sort()
+    return ",".join(split_list)
+
+classad.register(sortStringSet)
+


### PR DESCRIPTION
This adds a new function to the ClassAd language, sortStringSet,
which takes a list (of sites), converts it to a set (removing
duplicates), and sorts the output (to minimize the number of
unique strings - helps with matchmaking).

To use this, one needs to add the following lines to their HTCondor
configuration:

```
JOB_ROUTER.CLASSAD_USER_PYTHON_MODULES=unified_utils
JOB_ROUTER_ENVIRONMENT="PYTHONPATH=/data/srv/WmAgentScripts/Unified/job_router_modules"
JOB_ROUTER_DEBUG=D_FULLDEBUG
```

(adjusting the `/data/srv` prefix as necessary.)

The updated `go_condor.py` will only function for schedds where this
function is available; otherwise, it'll ignore jobs that can be
repeatedly routed.

To help with cleanup of current jobs with duplicates, I included
a `Sort Ads` route.
