### PR TITLE
Optimize overflow for matchmaking

### DIFF
--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -8,7 +8,8 @@ import classad
 import htcondor
 from collections import defaultdict
 
-def makeAds( config ):
+
+def makeAds(config):
     reversed_mapping = config['reversed_mapping']
 
     needs_site = defaultdict(set)
@@ -17,13 +18,15 @@ def makeAds( config ):
             anAd = classad.ClassAd()
             anAd["GridResource"] = "condor localhost localhost"
             anAd["TargetUniverse"] = 5
-            exp = '(target.WMAgent_SubTaskName =?= %s)'% classad.quote(str(taskname))
+            exp = '(HasBeenReplaced isnt true)  && (target.WMAgent_SubTaskName =?= %s)' % classad.quote(str(taskname))
             anAd["Requirements"] = classad.ExprTree(str(exp))
             
             if "ReplaceSiteWhitelist" in specs:
                 anAd["Name"] = str("Site Replacement for %s"% taskname)
                 anAd["eval_set_DESIRED_Sites"] = str(",".join(specs['ReplaceSiteWhitelist']))
                 anAd['set_Rank'] = classad.ExprTree("stringlistmember(GLIDEIN_CMSSite, ExtDESIRED_Sites)")
+                anAd["set_HasBeenReplaced"] = True
+                anAd["set_HasBeenRouted"] = False
                 print anAd
             elif "AddWhitelist" in specs:
                 for site in specs['AddWhitelist']:
@@ -40,14 +43,55 @@ def makeAds( config ):
         overflow_names_escaped = anAd.lookup('OverflowTasknames').__repr__()
         del anAd['OverflowTaskNames']
         exprs = ['regexp(%s, target.ExtDESIRED_Sites)'% classad.quote(str(origin)) for origin in reversed_mapping[site]]
-        exp = classad.ExprTree('member(target.WMAgent_SubTaskName, %s) && ( %s ) && (target.HasBeenRouted_%s =!= true)' % (overflow_names_escaped, str("||".join( exprs )), str(site)))
+        exp = classad.ExprTree('(sortStringSet(\"\") isnt error) && member(target.WMAgent_SubTaskName, %s) && ( %s ) && (target.HasBeenRouted_%s =!= true)' % (overflow_names_escaped, str("||".join( exprs )), str(site)))
         anAd["Requirements"] = classad.ExprTree(str(exp))
         anAd["copy_DESIRED_Sites"] = "Prev_DESIRED_Sites"
-        anAd["eval_set_DESIRED_Sites"] = classad.Function("strcat", str(site) + ",", classad.Attribute("Prev_DESIRED_Sites"))
+        anAd["eval_set_DESIRED_Sites"] = classad.Function("debug", classad.Function("sortStringSet", classad.Function("strcat", str(site) + ",", classad.Attribute("Prev_DESIRED_Sites"))))
         anAd['set_Rank'] = classad.ExprTree("stringlistmember(GLIDEIN_CMSSite, ExtDESIRED_Sites)")
         anAd['set_HasBeenRouted'] = False
         anAd['set_HasBeenRouted_%s' % str(site)] = True
         print anAd
+
+
+def makeSortAd():
+    anAd = classad.ClassAd()
+    anAd["GridResource"] = "condor localhost localhost"
+    anAd["TargetUniverse"] = 5
+    anAd["Name"] = "Sort Ads"
+    anAd["Requirements"] = classad.ExprTree("(sortStringSet(\"\") isnt error) && (target.HasBeenRouted is false) && (target.HasBeenSorted isnt true)")
+    anAd["copy_DESIRED_Sites"] = "Prev_DESIRED_Sites"
+    anAd["eval_set_DESIRED_Sites"] = classad.ExprTree("debug(sortStringSet(Prev_DESIRED_Sites))")
+    anAd["set_HasBeenSorted"] = True
+    anAd['set_HasBeenRouted'] = False
+    #print anAd
+
+
+def makePrioCorrections():
+    """
+    Optimize the PostJobPrio* entries for HTCondor matchmaking.
+
+    This will sort jobs within the schedd along the following criteria (higher is better):
+    1) # of sites in whitelist (lower is better).
+    2) Workflow ID (lower is better).
+    3) Estimated job runtime (lower is better).
+    4) Estimated job disk requirements (lower is better).
+    """
+    anAd = classad.ClassAd()
+    anAd["GridResource"] = "condor localhost localhost"
+    anAd["TargetUniverse"] = 5
+    anAd["Name"] = "Prio Corrections"
+    anAd["Requirements"] = classad.ExprTree("(target.HasPrioCorrection isnt true)")
+    anAd["set_HasPrioCorrection"] = True
+    anAd["set_HasBeenRouted"] = False
+    anAd["copy_PostJobPrio1"] = "WMAgent_PostJobPrio1"
+    anAd["copy_PostJobPrio2"] = "WMAgent_PostJobPrio2"
+    anAd["eval_set_JR_PostJobPrio1"] = classad.ExprTree("WMAgent_PostJobPrio1*10000000 + WMAgent_PostJobPrio2")
+    anAd["eval_set_JR_PostJobPrio2"] = classad.ExprTree("-MaxWallTimeMins - RequestDisk/1000000")
+    anAd["set_PostJobPrio1"] = classad.Attribute("JR_PostJobPrio1")
+    anAd["set_PostJobPrio2"] = classad.Attribute("JR_PostJobPrio2")
+    anAd["MaxJobs"] = 50
+    print anAd
+
 
 if __name__ == "__main__":
 
@@ -56,3 +100,5 @@ if __name__ == "__main__":
 
     config = json.load(urllib.urlopen(htcondor.param['UNIFIED_OVERFLOW_CONFIG']))
     makeAds(config)
+    makeSortAd()
+    makePrioCorrections()

--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -101,3 +101,4 @@ if __name__ == "__main__":
     config = json.load(urllib.urlopen(htcondor.param['UNIFIED_OVERFLOW_CONFIG']))
     makeAds(config)
     makeSortAd()
+    makePrioCorrections()

--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -8,7 +8,8 @@ import classad
 import htcondor
 from collections import defaultdict
 
-def makeAds( config ):
+
+def makeAds(config):
     reversed_mapping = config['reversed_mapping']
 
     needs_site = defaultdict(set)
@@ -40,14 +41,27 @@ def makeAds( config ):
         overflow_names_escaped = anAd.lookup('OverflowTasknames').__repr__()
         del anAd['OverflowTaskNames']
         exprs = ['regexp(%s, target.ExtDESIRED_Sites)'% classad.quote(str(origin)) for origin in reversed_mapping[site]]
-        exp = classad.ExprTree('member(target.WMAgent_SubTaskName, %s) && ( %s ) && (target.HasBeenRouted_%s =!= true)' % (overflow_names_escaped, str("||".join( exprs )), str(site)))
+        exp = classad.ExprTree('(sortStringSet(\"\") isnt error) && member(target.WMAgent_SubTaskName, %s) && ( %s ) && (target.HasBeenRouted_%s =!= true)' % (overflow_names_escaped, str("||".join( exprs )), str(site)))
         anAd["Requirements"] = classad.ExprTree(str(exp))
         anAd["copy_DESIRED_Sites"] = "Prev_DESIRED_Sites"
-        anAd["eval_set_DESIRED_Sites"] = classad.Function("strcat", str(site) + ",", classad.Attribute("Prev_DESIRED_Sites"))
+        anAd["eval_set_DESIRED_Sites"] = classad.Function("debug", classad.Function("sortStringSet", classad.Function("strcat", str(site) + ",", classad.Attribute("Prev_DESIRED_Sites"))))
         anAd['set_Rank'] = classad.ExprTree("stringlistmember(GLIDEIN_CMSSite, ExtDESIRED_Sites)")
         anAd['set_HasBeenRouted'] = False
         anAd['set_HasBeenRouted_%s' % str(site)] = True
         print anAd
+
+
+def makeSortAd():
+    anAd = classad.ClassAd()
+    anAd["GridResource"] = "condor localhost localhost"
+    anAd["TargetUniverse"] = 5
+    anAd["Name"] = "Sort Ads"
+    anAd["Requirements"] = classad.ExprTree("(sortStringSet(\"\") isnt error) && (target.HasBeenRouted is false) && (target.HasBeenSorted isnt true) && (sortStringSet("") isnt error)")
+    anAd["copy_DESIRED_Sites"] = "Prev_DESIRED_Sites"
+    anAd["eval_set_DESIRED_Sites"] = classad.ExprTree("debug(sortStringSet(Prev_DESIRED_Sites))")
+    anAd["set_HasBeenSorted"] = True
+    print anAd
+
 
 if __name__ == "__main__":
 
@@ -56,3 +70,4 @@ if __name__ == "__main__":
 
     config = json.load(urllib.urlopen(htcondor.param['UNIFIED_OVERFLOW_CONFIG']))
     makeAds(config)
+    makeSortAd()

--- a/Unified/job_router_modules/unified_utils.py
+++ b/Unified/job_router_modules/unified_utils.py
@@ -1,0 +1,17 @@
+
+import re
+import classad
+
+_split_re = re.compile(",\s*")
+def sortStringSet(in_list, state={}):
+    if isinstance(in_list, classad.ExprTree):
+        in_list = in_list.eval(state)
+    if isinstance(in_list, classad.Value):
+        return classad.Value.Undefined
+    split_list = _split_re.split(in_list)
+    split_list = list(set(split_list))
+    split_list.sort()
+    return ",".join(split_list)
+
+classad.register(sortStringSet)
+


### PR DESCRIPTION
This PR does two major changes:
1. Adds a custom classad function to make sure the `DESIRED_Sites` list is sorted and contains no duplicates.
2. When sending jobs to the negotiator, sort them first by wall time / disk request.  This groups identical jobs together (which reduces the number of jobs sent to the negotiator).

To get this working, one must add the following lines to the `condor_schedd` config:

```
JOB_ROUTER.CLASSAD_USER_PYTHON_MODULES=unified_utils
JOB_ROUTER_ENVIRONMENT="PYTHONPATH=/data/srv/WmAgentScripts/Unified/job_router_modules"
```

and restart (_not_ reconfig) the `condor_job_router`.

If the appropriate function is not found, then the relevant routes are disabled.  Thus, it's OK to merge this even before the corresponding HTCondor configuration changes are made.
